### PR TITLE
Add minimal MCP web search server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
 # agen-ai
+
+This repository contains a minimal MCP web search server implemented in Python.
+
+## Running the server
+
+```bash
+python3 mcp_server.py --port 8000
+```
+
+Then send a request to search the web:
+
+```bash
+curl "http://localhost:8000/search?q=openai"
+```
+
+The server queries DuckDuckGo's Instant Answer API and returns a JSON payload
+with the results. If network access is unavailable, the response will contain an
+`error` field describing the failure.

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -1,0 +1,71 @@
+import http.server
+import urllib.parse
+import urllib.request
+import json
+
+class MCPWebSearchHandler(http.server.BaseHTTPRequestHandler):
+    """Simple HTTP server handler for web search."""
+
+    def do_GET(self):
+        parsed = urllib.parse.urlparse(self.path)
+        if parsed.path != '/search':
+            self.send_response(404)
+            self.end_headers()
+            self.wfile.write(b'Not Found')
+            return
+
+        params = urllib.parse.parse_qs(parsed.query)
+        query = params.get('q')
+        if not query:
+            self.send_response(400)
+            self.end_headers()
+            self.wfile.write(b'Missing q parameter')
+            return
+        query = query[0]
+        results = fetch_duckduckgo(query)
+        response = json.dumps(results).encode('utf-8')
+
+        self.send_response(200)
+        self.send_header('Content-Type', 'application/json')
+        self.end_headers()
+        self.wfile.write(response)
+
+
+def fetch_duckduckgo(query: str):
+    """Fetch search results from DuckDuckGo Instant Answer API."""
+    url = (
+        "https://api.duckduckgo.com/?" +
+        urllib.parse.urlencode({"q": query, "format": "json", "no_redirect": 1, "no_html": 1})
+    )
+    try:
+        with urllib.request.urlopen(url) as resp:
+            return json.load(resp)
+    except Exception as exc:
+        return {"error": str(exc)}
+
+
+def run(port: int = 8000):
+    server_address = ('', port)
+    httpd = http.server.HTTPServer(server_address, MCPWebSearchHandler)
+    print(f'Serving on port {port}')
+    try:
+        httpd.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        httpd.server_close()
+
+
+if __name__ == '__main__':
+    import argparse
+
+    parser = argparse.ArgumentParser(description='MCP web search server')
+    parser.add_argument(
+        '--port',
+        type=int,
+        default=8000,
+        help='Port to listen on',
+    )
+    args = parser.parse_args()
+
+    run(port=args.port)


### PR DESCRIPTION
## Summary
- implement a simple web search server using DuckDuckGo's API
- document how to run the server

## Testing
- `python3 -m py_compile mcp_server.py`

------
https://chatgpt.com/codex/tasks/task_e_68488d4e04dc833287461bb471df796c