### PR TITLE
Add research agent example

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,23 @@ curl "http://localhost:8000/search?q=openai"
 The server queries DuckDuckGo's Instant Answer API and returns a JSON payload
 with the results. If network access is unavailable, the response will contain an
 `error` field describing the failure.
+
+## Research agent
+
+The repository includes `research_agent.py`, a simple example using the
+[AutoGen](https://github.com/microsoft/autogen) framework. The script
+creates a `DeepResearchAgent` and interacts with it via a `UserProxyAgent`.
+To run the agent, first provide LLM API credentials through a `.env` file
+or environment variables understood by `config_list_from_dotenv()`:
+
+```bash
+OPENAI_API_KEY=sk-...
+```
+
+Then execute the script with your research question:
+
+```bash
+python3 research_agent.py "What is the tallest mountain in the world?"
+```
+
+The agent will use AutoGen to answer the question using available web tools.

--- a/research_agent.py
+++ b/research_agent.py
@@ -1,0 +1,31 @@
+"""Example research agent using AutoGen's DeepResearchAgent."""
+
+from __future__ import annotations
+
+import argparse
+
+from autogen import UserProxyAgent, config_list_from_dotenv
+from autogen.agents.experimental.deep_research import DeepResearchAgent
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run a deep research agent")
+    parser.add_argument("question", help="Question to research")
+    args = parser.parse_args()
+
+    config_list = config_list_from_dotenv()
+    if not config_list:
+        raise RuntimeError(
+            "No LLM configuration found. Set an API key in a .env file or as environment variables."
+        )
+    llm_config = {"config_list": config_list}
+
+    user = UserProxyAgent("user", human_input_mode="NEVER")
+    researcher = DeepResearchAgent(name="researcher", llm_config=llm_config)
+
+    result = user.initiate_chat(researcher, message=args.question)
+    print(result.summary)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `research_agent.py` demonstrating DeepResearchAgent usage
- document how to run the research agent in README

## Testing
- `python3 -m py_compile research_agent.py mcp_server.py`


------
https://chatgpt.com/codex/tasks/task_e_6848907cae508332942253ce3d47c089